### PR TITLE
Sorting by ID not working properly

### DIFF
--- a/admin/slm-list-licenses-class.php
+++ b/admin/slm-list-licenses-class.php
@@ -303,7 +303,15 @@ class SLM_List_Licenses extends WP_List_Table
         if (!empty($_GET['order'])) {
             $order = $_GET['order'];
         }
-        $result = strcmp($a[$orderby], $b[$orderby]);
+        if ($orderby == 'id'){ 
+          if ($a[$orderby]==$b[$orderby]){
+            $result = 0;
+          }else{
+            $result = ($a[$orderby]<$b[$orderby])?-1:1;          
+          }
+        }else{
+          $result = strcmp($a[$orderby], $b[$orderby]);
+        }
         if ($order === 'asc') {
             return $result;
         }


### PR DESCRIPTION
When sorting by ID and comparing strings, the order is wrong - it sorts by the first letter in the string - example: descending order 99,98,97...100