### PR TITLE
fix: replace deprecated PHP 8.2+ functions

### DIFF
--- a/admin/slm-add-licenses.php
+++ b/admin/slm-add-licenses.php
@@ -104,7 +104,7 @@ function slm_add_licenses_menu()
         $subscr_id      = $_POST['subscr_id'];
         $lic_type       = $_POST['lic_type'];
 
-        if ("" == trim($_POST['item_reference'])) {
+        if (empty($_POST['item_reference'])) {
             $lic_item_ref   = 'default';
         } else {
             $lic_item_ref   = trim($_POST['item_reference']);

--- a/includes/slm-plugin-core.php
+++ b/includes/slm-plugin-core.php
@@ -92,7 +92,7 @@ function deactivate_software_license_manager()
 
 function slm_get_license($lic_key_prefix = '')
 {
-    return strtoupper($lic_key_prefix  . hyphenate(md5(uniqid(rand(4, 10), true) . date('Y-m-d H:i:s') . time())));
+    return strtoupper($lic_key_prefix  . hyphenate(md5(uniqid(rand(4, 10), true) . gmdate('Y-m-d H:i:s') . time())));
 }
 
 register_activation_hook(__FILE__, 'activate_software_license_manager');

--- a/woocommerce/includes/purchase.php
+++ b/woocommerce/includes/purchase.php
@@ -144,7 +144,7 @@ function wc_slm_create_license_keys($order_id)
                 // 	$renewal_period = date('Y-m-d', strtotime('+' . 31 . ' days'));
                 // }
                 else {
-                    $expiration = date('Y-m-d', strtotime('+' . $renewal_period . ' ' . $renewal_term));
+                    $expiration = wp_date('Y-m-d', strtotime('+' . $renewal_period . ' ' . $renewal_term));
                 }
                 // SLM_Helper_Class::write_log('renewal_period -- '.$renewal_period  );
                 // SLM_Helper_Class::write_log('exp -- ' . $expiration);
@@ -193,7 +193,7 @@ function wc_slm_create_license_keys($order_id)
                 $api_params['txn_id'] = $purchase_id_;
                 $api_params['max_allowed_domains'] = $sites_allowed;
                 $api_params['max_allowed_devices'] = $amount_of_licenses_devices;
-                $api_params['date_created'] = date('Y-m-d');
+                $api_params['date_created'] = wp_date('Y-m-d');
                 $api_params['date_expiry'] = $expiration;
                 $api_params['slm_billing_length'] = $slm_billing_length;
                 $api_params['slm_billing_interval'] = $slm_billing_interval;
@@ -252,7 +252,7 @@ function wc_slm_get_license_key($response)
         return false;
     }
     // Get License data
-    $json = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', utf8_encode(wp_remote_retrieve_body($response)));
+    $json = preg_replace('/[\x00-\x1F\x80-\xFF]/', '', mb_convert_encoding(wp_remote_retrieve_body($response), 'UTF-8', 'ISO-8859-1'));
     $license_data = json_decode($json);
 
     if (!isset($license_data->key)) {


### PR DESCRIPTION
## Summary

Fixes PHP 8.2+ deprecation warnings that corrupt JSON API responses (e.g. `slm_check`) when `error_reporting` includes `E_DEPRECATED`.

### Changes

- **`utf8_encode()`** → `mb_convert_encoding($str, 'UTF-8', 'ISO-8859-1')` in `woocommerce/includes/purchase.php:255`
  - `utf8_encode()` was deprecated in PHP 8.2 and will be removed in PHP 9.0
- **`date()`** → `wp_date()` in `woocommerce/includes/purchase.php:147,196`
  - Respects WordPress timezone settings, avoids PHP timezone warnings
- **`date()`** → `gmdate()` in `includes/slm-plugin-core.php:95`
  - Used for random seed generation (no display context), safe without WP timezone
- **`trim($_POST['item_reference'])`** → `empty($_POST['item_reference'])` in `admin/slm-add-licenses.php:107`
  - Avoids `Undefined array key` warning when the field is not submitted (e.g. via API calls that don't include `item_reference`)

### Why this matters

When PHP deprecation warnings fire during API responses, the warning text gets prepended to the JSON body, breaking `json_decode()` on the client side. This affects any integration that calls SLM endpoints (update servers, plugin license checks, WooCommerce purchases).

### Tested on
- PHP 8.4.7
- WordPress 6.9
- WooCommerce 9.x